### PR TITLE
Feat/delivery time edge case

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,6 +104,10 @@ Problem are solved in different PR, added the comment inside the code for better
 **Problem 02**
 [Feat/delivery time](https://github.com/kenchoong/courrier-service/pull/3)
 
+**Edge cases**
+[PR: Feat/delivery time edge case](https://github.com/kenchoong/courrier-service/pull/11)
+[Refer to this issues](https://github.com/kenchoong/courrier-service/issues/10)
+
 If you interested
 [Random analysis sketch of the problem 02(Github link)](./result/sketch.png)
 

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
     "build": "tsc",
     "start": "yarn build && node --experimental-specifier-resolution=node ./dist/main.js",
     "dev": "ts-node ./src/main.ts",
+    "clear": "node --experimental-vm-modules node_modules/jest/bin/jest.js --clearCache",
     "test": "tsc && node --experimental-vm-modules node_modules/jest/bin/jest.js",
     "test:time": "tsc && node --experimental-vm-modules node_modules/jest/bin/jest.js --testNamePattern DeliveryTimeService",
     "test:cost": "tsc && node --experimental-vm-modules node_modules/jest/bin/jest.js --testNamePattern DeliveryCostService",

--- a/src/use-case/delivery-time/delivery-time.service.spec.ts
+++ b/src/use-case/delivery-time/delivery-time.service.spec.ts
@@ -177,7 +177,7 @@ describe('DeliveryTimeService', () => {
       },
     ]
 
-    //expect(mockedDeliveryCostService.getPackagePriceDiscount).toBeCalledTimes(5)
+    expect(mockedDeliveryCostService.getPackagePriceDiscount).toBeCalledTimes(5)
     expect(result).toEqual(outcome)
   })
 

--- a/src/use-case/delivery-time/delivery-time.service.spec.ts
+++ b/src/use-case/delivery-time/delivery-time.service.spec.ts
@@ -13,6 +13,9 @@ import {
 } from './delivery-time.dto'
 import { DeliveryCostService } from '../delivery-cost/delivery-cost.service'
 import { DeliveryCostCalculatedDetails } from '../delivery-cost/delivery-cost.dto'
+import { mockedThreePackagesShouldSendFirst } from './utils/mocks/mock-three-packages-should-send-first..mock'
+import { mockedFourPackageShouldDeliveryFirst } from './utils/mocks/mock-four-packages-should-send-first.mock'
+import { mockFivePackagesShouldSendFirst } from './utils/mocks/mock-five-packages-should-send-first.mock'
 
 const mockedDeliveryCostService = mock<DeliveryCostService>()
 
@@ -39,7 +42,7 @@ describe('DeliveryTimeService', () => {
     expect(deliveryCostService).toBeDefined()
   })
 
-  it('Delivery time', async () => {
+  it('Delivery time standard requirement', async () => {
     const mockedOrignalPackageListStepO1: PackageDtoForTime[] = [
       {
         packageId: 'pkg1',
@@ -174,7 +177,301 @@ describe('DeliveryTimeService', () => {
       },
     ]
 
-    expect(mockedDeliveryCostService.getPackagePriceDiscount).toBeCalledTimes(5)
+    //expect(mockedDeliveryCostService.getPackagePriceDiscount).toBeCalledTimes(5)
+    expect(result).toEqual(outcome)
+  })
+
+  it('Delivery time, 3 packages send together', async () => {
+    // P1 0 1100 1.42
+    // P2 0 1100 1.42
+    // P3 105 1995 4.26
+    // P4 0 1590 7.10
+    // P5 0 1600 1.42
+
+    const input = {
+      vechileDetails: {
+        noOfVechiles: 1,
+        maxSpeed: 70,
+        maxCarriableWeight: 200,
+      },
+      packageList: mockedThreePackagesShouldSendFirst,
+    }
+
+    const mockCostResult: DeliveryCostCalculatedDetails[] = [
+      {
+        packageId: 'pkg1',
+        totalDiscountedAmount: 0,
+        totalDeliveryCostBeforeDiscount: 0,
+        totalDeliveryCostAfterDiscount: 1100,
+      },
+      {
+        packageId: 'pkg2',
+        totalDiscountedAmount: 0,
+        totalDeliveryCostBeforeDiscount: 0,
+        totalDeliveryCostAfterDiscount: 1100,
+      },
+      {
+        packageId: 'pkg3',
+        totalDiscountedAmount: 105,
+        totalDeliveryCostBeforeDiscount: 2100,
+        totalDeliveryCostAfterDiscount: 1995,
+      },
+      {
+        packageId: 'pkg4',
+        totalDiscountedAmount: 0,
+        totalDeliveryCostBeforeDiscount: 0,
+        totalDeliveryCostAfterDiscount: 1590,
+      },
+      {
+        packageId: 'pkg5',
+        totalDiscountedAmount: 0,
+        totalDeliveryCostBeforeDiscount: 0,
+        totalDeliveryCostAfterDiscount: 1600,
+      },
+    ]
+
+    mockedDeliveryCostService.getPackagePriceDiscount
+      .mockResolvedValueOnce(mockCostResult[0])
+      .mockResolvedValueOnce(mockCostResult[1])
+      .mockResolvedValueOnce(mockCostResult[2])
+      .mockResolvedValueOnce(mockCostResult[3])
+      .mockResolvedValueOnce(mockCostResult[4])
+
+    const outcome: DeliveryTimeResultDto[] = [
+      {
+        packageId: 'pkg1',
+        totalDiscountedAmount: 0,
+        estimatedDeliveryTime: 1.42,
+        totalDeliveryCostAfterDiscount: 1100,
+      },
+
+      {
+        packageId: 'pkg2',
+        totalDiscountedAmount: 0,
+        estimatedDeliveryTime: 1.42,
+        totalDeliveryCostAfterDiscount: 1100,
+      },
+
+      {
+        packageId: 'pkg3',
+        totalDiscountedAmount: 105,
+        estimatedDeliveryTime: 4.26,
+        totalDeliveryCostAfterDiscount: 1995,
+      },
+
+      {
+        packageId: 'pkg4',
+        totalDiscountedAmount: 0,
+        estimatedDeliveryTime: 7.1,
+        totalDeliveryCostAfterDiscount: 1590,
+      },
+
+      {
+        packageId: 'pkg5',
+        totalDiscountedAmount: 0,
+        estimatedDeliveryTime: 1.42,
+        totalDeliveryCostAfterDiscount: 1600,
+      },
+    ]
+
+    const result = await deliveryTimeService.calculateEstimatedDeliveryTime(
+      input,
+    )
+
+    expect(result).toEqual(outcome)
+  })
+
+  it('Delivery time, 4 packages send together', async () => {
+    const input = {
+      vechileDetails: {
+        noOfVechiles: 1,
+        maxSpeed: 70,
+        maxCarriableWeight: 200,
+      },
+      packageList: mockedFourPackageShouldDeliveryFirst,
+    }
+
+    //Base Delivery Cost + (Package Total Weight * 10) +
+    //(Distance to Destination * 5) =
+
+    const mockCostResult: DeliveryCostCalculatedDetails[] = [
+      {
+        packageId: 'pkg1',
+        totalDiscountedAmount: 0,
+        totalDeliveryCostBeforeDiscount: 900,
+        totalDeliveryCostAfterDiscount: 900,
+      },
+      {
+        packageId: 'pkg2',
+        totalDiscountedAmount: 0,
+        totalDeliveryCostBeforeDiscount: 1100,
+        totalDeliveryCostAfterDiscount: 1100,
+      },
+      {
+        packageId: 'pkg3',
+        totalDiscountedAmount: 0,
+        totalDeliveryCostBeforeDiscount: 1000,
+        totalDeliveryCostAfterDiscount: 1000,
+      },
+      {
+        packageId: 'pkg4',
+        totalDiscountedAmount: 0,
+        totalDeliveryCostBeforeDiscount: 1300,
+        totalDeliveryCostAfterDiscount: 1300,
+      },
+      {
+        packageId: 'pkg5',
+        totalDiscountedAmount: 0,
+        totalDeliveryCostBeforeDiscount: 0,
+        totalDeliveryCostAfterDiscount: 1600,
+      },
+    ]
+
+    mockedDeliveryCostService.getPackagePriceDiscount
+      .mockResolvedValueOnce(mockCostResult[0])
+      .mockResolvedValueOnce(mockCostResult[1])
+      .mockResolvedValueOnce(mockCostResult[2])
+      .mockResolvedValueOnce(mockCostResult[3])
+      .mockResolvedValueOnce(mockCostResult[4])
+
+    const outcome: DeliveryTimeResultDto[] = [
+      {
+        packageId: 'pkg1',
+        totalDiscountedAmount: 0,
+        estimatedDeliveryTime: 1.42,
+        totalDeliveryCostAfterDiscount: 900,
+      },
+
+      {
+        packageId: 'pkg2',
+        totalDiscountedAmount: 0,
+        estimatedDeliveryTime: 1.42,
+        totalDeliveryCostAfterDiscount: 1100,
+      },
+
+      {
+        packageId: 'pkg3',
+        totalDiscountedAmount: 0,
+        estimatedDeliveryTime: 1.42,
+        totalDeliveryCostAfterDiscount: 1000,
+      },
+
+      {
+        packageId: 'pkg4',
+        totalDiscountedAmount: 0,
+        estimatedDeliveryTime: 1.42,
+        totalDeliveryCostAfterDiscount: 1300,
+      },
+
+      {
+        packageId: 'pkg5',
+        totalDiscountedAmount: 0,
+        estimatedDeliveryTime: 4.26,
+        totalDeliveryCostAfterDiscount: 1600,
+      },
+    ]
+
+    const result = await deliveryTimeService.calculateEstimatedDeliveryTime(
+      input,
+    )
+
+    expect(result).toEqual(outcome)
+  })
+
+  it('Delivery time, 5 packages send together', async () => {
+    const input = {
+      vechileDetails: {
+        noOfVechiles: 1,
+        maxSpeed: 70,
+        maxCarriableWeight: 200,
+      },
+      packageList: mockFivePackagesShouldSendFirst,
+    }
+
+    //Base Delivery Cost + (Package Total Weight * 10) +
+    //(Distance to Destination * 5) =
+
+    const mockCostResult: DeliveryCostCalculatedDetails[] = [
+      {
+        packageId: 'pkg1',
+        totalDiscountedAmount: 0,
+        totalDeliveryCostBeforeDiscount: 900,
+        totalDeliveryCostAfterDiscount: 900,
+      },
+      {
+        packageId: 'pkg2',
+        totalDiscountedAmount: 0,
+        totalDeliveryCostBeforeDiscount: 1100,
+        totalDeliveryCostAfterDiscount: 1100,
+      },
+      {
+        packageId: 'pkg3',
+        totalDiscountedAmount: 0,
+        totalDeliveryCostBeforeDiscount: 1000,
+        totalDeliveryCostAfterDiscount: 1000,
+      },
+      {
+        packageId: 'pkg4',
+        totalDiscountedAmount: 0,
+        totalDeliveryCostBeforeDiscount: 1300,
+        totalDeliveryCostAfterDiscount: 1300,
+      },
+      {
+        packageId: 'pkg5',
+        totalDiscountedAmount: 0,
+        totalDeliveryCostBeforeDiscount: 0,
+        totalDeliveryCostAfterDiscount: 650,
+      },
+    ]
+
+    mockedDeliveryCostService.getPackagePriceDiscount
+      .mockResolvedValueOnce(mockCostResult[0])
+      .mockResolvedValueOnce(mockCostResult[1])
+      .mockResolvedValueOnce(mockCostResult[2])
+      .mockResolvedValueOnce(mockCostResult[3])
+      .mockResolvedValueOnce(mockCostResult[4])
+
+    const outcome: DeliveryTimeResultDto[] = [
+      {
+        packageId: 'pkg1',
+        totalDiscountedAmount: 0,
+        estimatedDeliveryTime: 1.42,
+        totalDeliveryCostAfterDiscount: 900,
+      },
+
+      {
+        packageId: 'pkg2',
+        totalDiscountedAmount: 0,
+        estimatedDeliveryTime: 1.42,
+        totalDeliveryCostAfterDiscount: 1100,
+      },
+
+      {
+        packageId: 'pkg3',
+        totalDiscountedAmount: 0,
+        estimatedDeliveryTime: 1.42,
+        totalDeliveryCostAfterDiscount: 1000,
+      },
+
+      {
+        packageId: 'pkg4',
+        totalDiscountedAmount: 0,
+        estimatedDeliveryTime: 1.42,
+        totalDeliveryCostAfterDiscount: 1300,
+      },
+
+      {
+        packageId: 'pkg5',
+        totalDiscountedAmount: 0,
+        estimatedDeliveryTime: 1.42,
+        totalDeliveryCostAfterDiscount: 650,
+      },
+    ]
+
+    const result = await deliveryTimeService.calculateEstimatedDeliveryTime(
+      input,
+    )
+
     expect(result).toEqual(outcome)
   })
 })

--- a/src/use-case/delivery-time/delivery-time.service.spec.ts
+++ b/src/use-case/delivery-time/delivery-time.service.spec.ts
@@ -16,6 +16,7 @@ import { DeliveryCostCalculatedDetails } from '../delivery-cost/delivery-cost.dt
 import { mockedThreePackagesShouldSendFirst } from './utils/mocks/mock-three-packages-should-send-first..mock'
 import { mockedFourPackageShouldDeliveryFirst } from './utils/mocks/mock-four-packages-should-send-first.mock'
 import { mockFivePackagesShouldSendFirst } from './utils/mocks/mock-five-packages-should-send-first.mock'
+import { mockUltimateSituation } from './utils/mocks/mock-ultimate-situation.mock'
 
 const mockedDeliveryCostService = mock<DeliveryCostService>()
 
@@ -291,9 +292,6 @@ describe('DeliveryTimeService', () => {
       packageList: mockedFourPackageShouldDeliveryFirst,
     }
 
-    //Base Delivery Cost + (Package Total Weight * 10) +
-    //(Distance to Destination * 5) =
-
     const mockCostResult: DeliveryCostCalculatedDetails[] = [
       {
         packageId: 'pkg1',
@@ -388,9 +386,6 @@ describe('DeliveryTimeService', () => {
       packageList: mockFivePackagesShouldSendFirst,
     }
 
-    //Base Delivery Cost + (Package Total Weight * 10) +
-    //(Distance to Destination * 5) =
-
     const mockCostResult: DeliveryCostCalculatedDetails[] = [
       {
         packageId: 'pkg1',
@@ -465,6 +460,131 @@ describe('DeliveryTimeService', () => {
         totalDiscountedAmount: 0,
         estimatedDeliveryTime: 1.42,
         totalDeliveryCostAfterDiscount: 650,
+      },
+    ]
+
+    const result = await deliveryTimeService.calculateEstimatedDeliveryTime(
+      input,
+    )
+
+    expect(result).toEqual(outcome)
+  })
+
+  it('Delivery time, 7 packages, cover all situation together', async () => {
+    // how it works
+    // https://github.com/kenchoong/courrier-service/issues/10#issuecomment-1289250226
+
+    const input = {
+      vechileDetails: {
+        noOfVechiles: 1,
+        maxSpeed: 70,
+        maxCarriableWeight: 200,
+      },
+      packageList: mockUltimateSituation,
+    }
+
+    const mockCostResult: DeliveryCostCalculatedDetails[] = [
+      {
+        packageId: 'pkg1',
+        totalDiscountedAmount: 0,
+        totalDeliveryCostBeforeDiscount: 900,
+        totalDeliveryCostAfterDiscount: 900,
+      },
+      {
+        packageId: 'pkg2',
+        totalDiscountedAmount: 0,
+        totalDeliveryCostBeforeDiscount: 1100,
+        totalDeliveryCostAfterDiscount: 1100,
+      },
+      {
+        packageId: 'pkg3',
+        totalDiscountedAmount: 0,
+        totalDeliveryCostBeforeDiscount: 1000,
+        totalDeliveryCostAfterDiscount: 1000,
+      },
+
+      {
+        packageId: 'pkg5',
+        totalDiscountedAmount: 0,
+        totalDeliveryCostBeforeDiscount: 0,
+        totalDeliveryCostAfterDiscount: 1550,
+      },
+      {
+        packageId: 'pkg6',
+        totalDiscountedAmount: 0,
+        totalDeliveryCostBeforeDiscount: 1400,
+        totalDeliveryCostAfterDiscount: 1400,
+      },
+      {
+        packageId: 'pkg7',
+        totalDiscountedAmount: 0,
+        totalDeliveryCostBeforeDiscount: 1700,
+        totalDeliveryCostAfterDiscount: 1700,
+      },
+      {
+        packageId: 'pkg8',
+        totalDiscountedAmount: 0,
+        totalDeliveryCostBeforeDiscount: 1200,
+        totalDeliveryCostAfterDiscount: 1200,
+      },
+    ]
+
+    mockedDeliveryCostService.getPackagePriceDiscount
+      .mockResolvedValueOnce(mockCostResult[0])
+      .mockResolvedValueOnce(mockCostResult[1])
+      .mockResolvedValueOnce(mockCostResult[2])
+      .mockResolvedValueOnce(mockCostResult[3])
+      .mockResolvedValueOnce(mockCostResult[4])
+      .mockResolvedValueOnce(mockCostResult[5])
+      .mockResolvedValueOnce(mockCostResult[6])
+
+    const outcome: DeliveryTimeResultDto[] = [
+      {
+        packageId: 'pkg1',
+        totalDiscountedAmount: 0,
+        estimatedDeliveryTime: 1.42,
+        totalDeliveryCostAfterDiscount: 900,
+      },
+
+      {
+        packageId: 'pkg2',
+        totalDiscountedAmount: 0,
+        estimatedDeliveryTime: 1.42,
+        totalDeliveryCostAfterDiscount: 1100,
+      },
+
+      {
+        packageId: 'pkg3',
+        totalDiscountedAmount: 0,
+        estimatedDeliveryTime: 1.42,
+        totalDeliveryCostAfterDiscount: 1000,
+      },
+
+      {
+        packageId: 'pkg5',
+        totalDiscountedAmount: 0,
+        estimatedDeliveryTime: 6.96, //1.28(90/70) +  5.68(2.84*2)
+        totalDeliveryCostAfterDiscount: 1550,
+      },
+      {
+        packageId: 'pkg6',
+        totalDiscountedAmount: 0,
+        estimatedDeliveryTime: 4.12, // 1.28(90/70) + 2.84(1.42 * 2),
+        totalDeliveryCostAfterDiscount: 1400,
+      },
+
+      {
+        packageId: 'pkg7',
+        totalDiscountedAmount: 0,
+        estimatedDeliveryTime: 4.26, // 1.42(100/70) + 2.84(1.42 * 2),
+        totalDeliveryCostAfterDiscount: 1700,
+      },
+
+      {
+        packageId: 'pkg8',
+        totalDiscountedAmount: 0,
+        estimatedDeliveryTime: 6.68, //1(70/70)  + 5.68(2.84 * 2),
+        totalDeliveryCostAfterDiscount: 1200,
       },
     ]
 

--- a/src/use-case/delivery-time/utils/decide-send-first-combo.spec.ts
+++ b/src/use-case/delivery-time/utils/decide-send-first-combo.spec.ts
@@ -1,0 +1,182 @@
+import { PackageDtoForTime } from '../delivery-time.dto'
+import { decideSendFirstCombo } from './decide-send-first-combo'
+
+describe('decideSendFirstCombo', () => {
+  it('should return combo that have biggest amount of packages', () => {
+    const packageComboList: PackageDtoForTime[][] = [
+      [
+        {
+          packageId: '1',
+          weightInKg: 1,
+          distanceInKm: 1,
+          baseDeliveryCost: 100,
+          sequence: 5,
+          offerCode: 'OFFER1',
+        },
+        {
+          packageId: '2',
+          weightInKg: 1,
+          distanceInKm: 1,
+          baseDeliveryCost: 100,
+          sequence: 5,
+          offerCode: 'OFFER1',
+        },
+      ],
+      [
+        {
+          packageId: '3',
+          weightInKg: 1,
+          distanceInKm: 1,
+          baseDeliveryCost: 100,
+          sequence: 5,
+          offerCode: 'OFFER1',
+        },
+      ],
+    ]
+
+    const result = decideSendFirstCombo(packageComboList)
+
+    expect(result).toEqual([
+      {
+        packageId: '1',
+        weightInKg: 1,
+        distanceInKm: 1,
+        baseDeliveryCost: 100,
+        sequence: 5,
+        offerCode: 'OFFER1',
+      },
+      {
+        packageId: '2',
+        weightInKg: 1,
+        distanceInKm: 1,
+        baseDeliveryCost: 100,
+        sequence: 5,
+        offerCode: 'OFFER1',
+      },
+    ])
+  })
+
+  it('should return combo that have biggest total weight if more than one combo having same amount of packages', () => {
+    const packageComboList: PackageDtoForTime[][] = [
+      [
+        {
+          packageId: '1',
+          weightInKg: 1,
+          distanceInKm: 1,
+          baseDeliveryCost: 100,
+          sequence: 5,
+          offerCode: 'OFFER1',
+        },
+        {
+          packageId: '2',
+          weightInKg: 1,
+          distanceInKm: 1,
+          baseDeliveryCost: 100,
+          sequence: 5,
+          offerCode: 'OFFER1',
+        },
+      ],
+      [
+        {
+          packageId: '3',
+          weightInKg: 20,
+          distanceInKm: 1,
+          baseDeliveryCost: 100,
+          sequence: 5,
+          offerCode: 'OFFER1',
+        },
+        {
+          packageId: '4',
+          weightInKg: 20,
+          distanceInKm: 1,
+          baseDeliveryCost: 100,
+          sequence: 5,
+          offerCode: 'OFFER1',
+        },
+      ],
+    ]
+
+    const result = decideSendFirstCombo(packageComboList)
+
+    expect(result).toEqual([
+      {
+        packageId: '3',
+        weightInKg: 20,
+        distanceInKm: 1,
+        baseDeliveryCost: 100,
+        sequence: 5,
+        offerCode: 'OFFER1',
+      },
+      {
+        packageId: '4',
+        weightInKg: 20,
+        distanceInKm: 1,
+        baseDeliveryCost: 100,
+        sequence: 5,
+        offerCode: 'OFFER1',
+      },
+    ])
+  })
+
+  it('should return combo that have biggest total distance if more than one combo having same amount of packages and same total weight', () => {
+    const packageComboList: PackageDtoForTime[][] = [
+      [
+        {
+          packageId: '1',
+          weightInKg: 20,
+          distanceInKm: 1,
+          baseDeliveryCost: 100,
+          sequence: 5,
+          offerCode: 'OFFER1',
+        },
+        {
+          packageId: '2',
+          weightInKg: 20,
+          distanceInKm: 1,
+          baseDeliveryCost: 100,
+          sequence: 5,
+          offerCode: 'OFFER1',
+        },
+      ],
+      [
+        {
+          packageId: '3',
+          weightInKg: 20,
+          distanceInKm: 3,
+          baseDeliveryCost: 100,
+          sequence: 5,
+          offerCode: 'OFFER1',
+        },
+        {
+          packageId: '4',
+          weightInKg: 20,
+          distanceInKm: 5,
+          baseDeliveryCost: 100,
+          sequence: 5,
+          offerCode: 'OFFER1',
+        },
+      ],
+    ]
+
+    const result = decideSendFirstCombo(packageComboList)
+
+    expect(result).toEqual([
+      {
+        packageId: '3',
+        weightInKg: 20,
+        distanceInKm: 3,
+        baseDeliveryCost: 100,
+        sequence: 5,
+        offerCode: 'OFFER1',
+      },
+      {
+        packageId: '4',
+        weightInKg: 20,
+        distanceInKm: 5,
+        baseDeliveryCost: 100,
+        sequence: 5,
+        offerCode: 'OFFER1',
+      },
+    ])
+  })
+})

--- a/src/use-case/delivery-time/utils/decide-send-first-combo.ts
+++ b/src/use-case/delivery-time/utils/decide-send-first-combo.ts
@@ -1,0 +1,58 @@
+import { PackageDtoForTime } from '../delivery-time.dto'
+
+/**
+ * Maximize the number of package first
+ * - If the number of package is the same,
+ *   maximize the total weight of the package in combo
+ * - If the total weight is the same,
+ *   maximize the total distance of the package in combo
+ * @param packageComboList
+ * @returns array of package combo(which should send first)
+ */
+export function decideSendFirstCombo(
+  packageComboList: PackageDtoForTime[][],
+): PackageDtoForTime[] {
+  return packageComboList.reduce((prev, current) => {
+    if (current.length > prev.length) {
+      return current
+    } else if (current.length === prev.length) {
+      // check for sum of weight
+      const currentComboSum = current.reduce((accumulate, currentCombo) => {
+        return accumulate + currentCombo.weightInKg
+      }, 0)
+
+      const previousComboSum = prev.reduce((accumulate, previousCombo) => {
+        return accumulate + previousCombo.weightInKg
+      }, 0)
+
+      if (currentComboSum > previousComboSum) {
+        return current
+      } else if (currentComboSum === previousComboSum) {
+        // check for sum of distance
+        const currentComboDistance = current.reduce(
+          (accumulate, currentCombo) => {
+            return accumulate + currentCombo.distanceInKm
+          },
+          0,
+        )
+
+        const previousComboDistance = prev.reduce(
+          (accumulate, previousCombo) => {
+            return accumulate + previousCombo.distanceInKm
+          },
+          0,
+        )
+
+        if (currentComboDistance > previousComboDistance) {
+          return current
+        } else {
+          return prev
+        }
+      } else {
+        return prev
+      }
+    } else {
+      return prev
+    }
+  })
+}

--- a/src/use-case/delivery-time/utils/get-package-combo-per-trip.spec.ts
+++ b/src/use-case/delivery-time/utils/get-package-combo-per-trip.spec.ts
@@ -1,5 +1,8 @@
 import { PackageDtoForTime } from '../delivery-time.dto'
 import { getPackageComboPerTrip } from './get-package-combo-per-trip'
+import { mockFivePackagesShouldSendFirst } from './mocks/mock-five-packages-should-send-first.mock'
+import { mockedFourPackageShouldDeliveryFirst } from './mocks/mock-four-packages-should-send-first.mock'
+import { mockedThreePackagesShouldSendFirst } from './mocks/mock-three-packages-should-send-first..mock'
 
 describe('getPackageComboPerTrip', () => {
   let maxCarriableWeight = 200
@@ -189,5 +192,134 @@ describe('getPackageComboPerTrip', () => {
     )
 
     expect(result).toEqual(outcome)
+  })
+
+  it('getPackageComboPerTrip, Edge case, if sum of 3 packages still less than vechile max weight', () => {
+    const input = mockedThreePackagesShouldSendFirst
+
+    const mockedOutcome = [
+      {
+        packageId: 'pkg1',
+        weightInKg: 50,
+        distanceInKm: 100,
+        offerCode: 'off001',
+        baseDeliveryCost: 100,
+        sequence: 0,
+      },
+      {
+        packageId: 'pkg2',
+        weightInKg: 50,
+        distanceInKm: 100,
+        offerCode: 'off008',
+        baseDeliveryCost: 100,
+        sequence: 1,
+      },
+      {
+        packageId: 'pkg5',
+        weightInKg: 100,
+        distanceInKm: 100,
+        offerCode: 'off001',
+        baseDeliveryCost: 100,
+        sequence: 4,
+      },
+    ]
+
+    const result = getPackageComboPerTrip(input, maxCarriableWeight)
+
+    expect(result).toEqual(mockedOutcome)
+  })
+
+  it('getPackageComboPerTrip, Edge case, if sum of 4 packages still less than vechile max weight', () => {
+    const input = mockedFourPackageShouldDeliveryFirst
+
+    const mockedOutcome = [
+      {
+        packageId: 'pkg1',
+        weightInKg: 30,
+        distanceInKm: 100,
+        offerCode: 'off002',
+        baseDeliveryCost: 100,
+        sequence: 0,
+      },
+      {
+        packageId: 'pkg2',
+        weightInKg: 50,
+        distanceInKm: 100,
+        offerCode: 'off001',
+        baseDeliveryCost: 100,
+        sequence: 1,
+      },
+      {
+        packageId: 'pkg3',
+        weightInKg: 40,
+        distanceInKm: 100,
+        offerCode: 'off003',
+        baseDeliveryCost: 100,
+        sequence: 2,
+      },
+      {
+        packageId: 'pkg4',
+        weightInKg: 70,
+        distanceInKm: 100,
+        offerCode: 'off001',
+        baseDeliveryCost: 100,
+        sequence: 3,
+      },
+    ]
+
+    const result = getPackageComboPerTrip(input, maxCarriableWeight)
+
+    expect(result).toEqual(mockedOutcome)
+  })
+
+  it('getPackageComboPerTrip, Edge case, if sum of 5 packages still less than vechile max weight', () => {
+    const input = mockFivePackagesShouldSendFirst
+
+    const mockedOutcome = [
+      {
+        packageId: 'pkg1',
+        weightInKg: 30,
+        distanceInKm: 100,
+        offerCode: 'off002',
+        baseDeliveryCost: 100,
+        sequence: 0,
+      },
+      {
+        packageId: 'pkg2',
+        weightInKg: 50,
+        distanceInKm: 100,
+        offerCode: 'off001',
+        baseDeliveryCost: 100,
+        sequence: 1,
+      },
+      {
+        packageId: 'pkg3',
+        weightInKg: 40,
+        distanceInKm: 100,
+        offerCode: 'off003',
+        baseDeliveryCost: 100,
+        sequence: 2,
+      },
+      {
+        packageId: 'pkg4',
+        weightInKg: 70,
+        distanceInKm: 100,
+        offerCode: 'off001',
+        baseDeliveryCost: 100,
+        sequence: 3,
+      },
+      {
+        packageId: 'pkg5',
+        weightInKg: 5,
+        distanceInKm: 100,
+        offerCode: 'off001',
+        baseDeliveryCost: 100,
+        sequence: 4,
+      },
+    ]
+
+    const result = getPackageComboPerTrip(input, maxCarriableWeight)
+
+    expect(result).toEqual(mockedOutcome)
   })
 })

--- a/src/use-case/delivery-time/utils/get-package-combo-per-trip.ts
+++ b/src/use-case/delivery-time/utils/get-package-combo-per-trip.ts
@@ -1,112 +1,53 @@
 import { PackageDtoForTime } from '../delivery-time.dto'
+import { decideSendFirstCombo } from './decide-send-first-combo'
 
-/**
- *
- * Given list of package, with their distance and weight
- * Given the max load of all our vechiles
- *
- * Calculate and select the combination of package weight
- * that is closest to the max load of our vechiles
- * for 1 trip
- *
- * Given:
- * maxLoad = 200
- * packageList(only weight)= [ 50, 75 , 175, 110, 155 ]
- *
- * get the highest combination of package weight that is closest to maxLoad
- * Output: [ 75, 110 ]
- * Then return the list 2nd and 4th package from the packageList
- *
- * if no combination of package weight is found,
- * return highest weight package into the list
- *
- * @param packageList (List of packages to be delivered)
- * @param maxCarriableWeight
- * @returns packageList[] (List of packages to be delivered in 1 trip)
- */
+export function powerSet(array: PackageDtoForTime[]): PackageDtoForTime[][] {
+  if (array.length === 0) {
+    return [[]]
+  }
+
+  var lastElement = array.pop() as PackageDtoForTime
+
+  var restPowerset = powerSet(array)
+
+  var powerset = []
+  for (var i = 0; i < restPowerset.length; i++) {
+    var set = restPowerset[i]
+
+    // without last element
+    powerset.push(set)
+
+    // with last element
+    set = set.slice() // create a new array that's a copy of set
+    set.push(lastElement)
+    powerset.push(set)
+  }
+
+  return powerset
+}
+
 export function getPackageComboPerTrip(
   packageList: PackageDtoForTime[],
   maxCarriableWeight: number,
 ) {
-  let possiblePackagesCombo: PackageDtoForTime[][] = []
+  // all subsets of arr
+  var powerset = powerSet(packageList)
 
-  const originalState = { weightInKg: 0 } as PackageDtoForTime
+  // subsets summing less than or equal to number
+  var subsets: PackageDtoForTime[][] = []
 
-  // Given package weight = [ 50, 75 , 175, 110, 155 ]
-  // Generate all possible combination of package
-  // Will produce result like this:
-  // [
-  //   [ 50 ],      [ 75 ],
-  //   [ 50, 75 ],  [ 175 ],
-  //   [ 110 ],     [ 50, 110 ],
-  //   [ 75, 110 ], [ 155 ]
-  // ]
-  // For M << 1, left shift in js, reference below:
-  // https://stackoverflow.com/questions/38922606/what-is-x-1-and-x-1
-  // https://stackoverflow.com/a/49143693/4332049
-  let M = 1 << packageList.length
-  for (var i = 1; i < M; ++i) {
-    var sublist = packageList.filter(function (c, k) {
-      return (i >> k) & 1
-    })
-    if (
-      sublist.reduce((previous, current) => {
-        return {
-          ...current,
-          weightInKg: previous.weightInKg + current.weightInKg,
-        }
-      }, originalState).weightInKg <= maxCarriableWeight
-    ) {
-      possiblePackagesCombo.push(sublist)
+  for (var i = 0; i < powerset.length; i++) {
+    var subset = powerset[i]
+
+    var sum = 0
+    for (var j = 0; j < subset.length; j++) {
+      sum += subset[j].weightInKg
+    }
+
+    if (sum <= maxCarriableWeight) {
+      subsets.push(subset)
     }
   }
 
-  // sum up each element inside each element(array) inside possiblePackagesCombo array
-  // sum only the weightInKg property
-  // from possible package above
-  // produce this stimulation below.
-  // sumUpAlpossiblePackagesComboInList = [
-  //     50,  75, 125, 175,
-  //    110, 160, 185, 155
-  //  ]
-  // (stimution value above only for weightInKg property)
-  const sumUpAlpossiblePackagesComboInList: PackageDtoForTime[] =
-    possiblePackagesCombo.map((x) =>
-      x.reduce(
-        (previous, current) => ({
-          ...current,
-          weightInKg: previous.weightInKg + current.weightInKg,
-        }),
-        originalState,
-      ),
-    )
-
-  // Find the highest combination of package weight that is closest to maxLoad
-  // from sumUpAlpossiblePackagesComboInList
-  // produce 185 (closest to maxCarriableWeight = 200)
-  // therefore get the whole object
-  const calculateClosetCombination: PackageDtoForTime =
-    sumUpAlpossiblePackagesComboInList.reduce((prev, current) => {
-      const prevWeight = Math.abs(prev.weightInKg - maxCarriableWeight)
-
-      const currentWeight = Math.abs(current.weightInKg - maxCarriableWeight)
-      if (currentWeight < prevWeight) {
-        return current
-      } else {
-        return prev
-      }
-    }, originalState)
-
-  // From sumUpAlpossiblePackagesComboInList
-  // get index of calculated closest combination
-  const indexOfItem = sumUpAlpossiblePackagesComboInList.indexOf(
-    calculateClosetCombination,
-  )
-
-  // possiblePackagesCombo[indexOfItem]  = sumUpAlpossiblePackagesComboInList[indexOfItem]
-  // This is the combination of package weight that is closest to maxLoad
-  // Which is [ 75, 110 ]
-  const closestCombination = possiblePackagesCombo[indexOfItem]
-
-  return closestCombination
+  return decideSendFirstCombo(subsets)
 }

--- a/src/use-case/delivery-time/utils/get-package-combo-sequence.spec.ts
+++ b/src/use-case/delivery-time/utils/get-package-combo-sequence.spec.ts
@@ -1,0 +1,284 @@
+import { getPackageComboSequence } from './get-package-combo-sequence'
+import { mockedDeliveryTimeStandardRequirement } from './mocks/mock-delivery-time-standard-requirement.mock'
+import { mockedFourPackageShouldDeliveryFirst } from './mocks/mock-four-packages-should-send-first.mock'
+import { mockedThreePackagesShouldSendFirst } from './mocks/mock-three-packages-should-send-first..mock'
+import { mockedTwoComboSameLengthAndWeightDifferenceDistance } from './mocks/mock-two-combo-same-length-and-weight-different-distance.mock'
+import { mockedTwoComboSameLengthDifferentWeight } from './mocks/mock-two-combo-same-length-different-weight.mock'
+describe('getPackageComboSequence', () => {
+  const maxCarriableWeight = 200
+
+  it('Standard case: should return the correct sequence of package combo', () => {
+    const input = mockedDeliveryTimeStandardRequirement
+
+    const result = getPackageComboSequence(input, maxCarriableWeight)
+
+    expect(result).toEqual([
+      [
+        {
+          packageId: 'pkg2',
+          weightInKg: 75,
+          distanceInKm: 125,
+          offerCode: 'off008',
+          baseDeliveryCost: 100,
+          sequence: 1,
+        },
+        {
+          packageId: 'pkg4',
+          weightInKg: 110,
+          distanceInKm: 60,
+          offerCode: 'off002',
+          baseDeliveryCost: 100,
+          sequence: 3,
+        },
+      ],
+      [
+        {
+          packageId: 'pkg3',
+          weightInKg: 175,
+          distanceInKm: 100,
+          offerCode: 'off003',
+          baseDeliveryCost: 100,
+          sequence: 2,
+        },
+      ],
+      [
+        {
+          packageId: 'pkg5',
+          weightInKg: 155,
+          distanceInKm: 95,
+          offerCode: 'off001',
+          baseDeliveryCost: 100,
+          sequence: 4,
+        },
+      ],
+      [
+        {
+          packageId: 'pkg1',
+          weightInKg: 50,
+          distanceInKm: 30,
+          offerCode: 'off001',
+          baseDeliveryCost: 100,
+          sequence: 0,
+        },
+      ],
+    ])
+  })
+
+  it('Edge case 1: three package sum up less than maxCarriableWeight', () => {
+    const input = mockedThreePackagesShouldSendFirst
+
+    const result = getPackageComboSequence(input, maxCarriableWeight)
+
+    expect(result).toEqual([
+      [
+        {
+          packageId: 'pkg1',
+          weightInKg: 50,
+          distanceInKm: 100,
+          offerCode: 'off001',
+          baseDeliveryCost: 100,
+          sequence: 0,
+        },
+        {
+          packageId: 'pkg2',
+          weightInKg: 50,
+          distanceInKm: 100,
+          offerCode: 'off008',
+          baseDeliveryCost: 100,
+          sequence: 1,
+        },
+        {
+          packageId: 'pkg5',
+          weightInKg: 100,
+          distanceInKm: 100,
+          offerCode: 'off001',
+          baseDeliveryCost: 100,
+          sequence: 4,
+        },
+      ],
+      [
+        {
+          packageId: 'pkg3',
+          weightInKg: 150,
+          distanceInKm: 100,
+          offerCode: 'off003',
+          baseDeliveryCost: 100,
+          sequence: 2,
+        },
+      ],
+      [
+        {
+          packageId: 'pkg4',
+          weightInKg: 99,
+          distanceInKm: 100,
+          offerCode: 'off002',
+          baseDeliveryCost: 100,
+          sequence: 3,
+        },
+      ],
+    ])
+  })
+
+  it('Edge case 2: four package sum up less than maxCarriableWeight', () => {
+    const input = mockedFourPackageShouldDeliveryFirst
+
+    const result = getPackageComboSequence(input, maxCarriableWeight)
+
+    expect(result).toEqual([
+      [
+        {
+          packageId: 'pkg1',
+          weightInKg: 30,
+          distanceInKm: 100,
+          offerCode: 'off002',
+          baseDeliveryCost: 100,
+          sequence: 0,
+        },
+        {
+          packageId: 'pkg2',
+          weightInKg: 50,
+          distanceInKm: 100,
+          offerCode: 'off001',
+          baseDeliveryCost: 100,
+          sequence: 1,
+        },
+        {
+          packageId: 'pkg3',
+          weightInKg: 40,
+          distanceInKm: 100,
+          offerCode: 'off003',
+          baseDeliveryCost: 100,
+          sequence: 2,
+        },
+        {
+          packageId: 'pkg4',
+          weightInKg: 70,
+          distanceInKm: 100,
+          offerCode: 'off001',
+          baseDeliveryCost: 100,
+          sequence: 3,
+        },
+      ],
+      [
+        {
+          packageId: 'pkg5',
+          weightInKg: 100,
+          distanceInKm: 100,
+          offerCode: 'off001',
+          baseDeliveryCost: 100,
+          sequence: 4,
+        },
+      ],
+    ])
+  })
+
+  it('Edge case 3: two combo have same length different weight', () => {
+    const input = mockedTwoComboSameLengthDifferentWeight
+
+    const result = getPackageComboSequence(input, maxCarriableWeight)
+
+    expect(result).toEqual([
+      [
+        {
+          packageId: 'pkg1',
+          weightInKg: 140,
+          distanceInKm: 100,
+          offerCode: 'off001',
+          baseDeliveryCost: 100,
+          sequence: 0,
+        },
+        {
+          packageId: 'pkg2',
+          weightInKg: 60,
+          distanceInKm: 200,
+          offerCode: 'off008',
+          baseDeliveryCost: 100,
+          sequence: 1,
+        },
+      ],
+      [
+        {
+          packageId: 'pkg3',
+          weightInKg: 130,
+          distanceInKm: 100,
+          offerCode: 'off003',
+          baseDeliveryCost: 100,
+          sequence: 2,
+        },
+        {
+          packageId: 'pkg4',
+          weightInKg: 50,
+          distanceInKm: 100,
+          offerCode: 'off002',
+          baseDeliveryCost: 100,
+          sequence: 3,
+        },
+      ],
+      [
+        {
+          packageId: 'pkg5',
+          weightInKg: 100,
+          distanceInKm: 100,
+          offerCode: 'off001',
+          baseDeliveryCost: 100,
+          sequence: 4,
+        },
+      ],
+    ])
+  })
+
+  it('Edge case 4: 2 combo having same package amount and weight sum, but different distance sum', () => {
+    const input = mockedTwoComboSameLengthAndWeightDifferenceDistance
+
+    const result = getPackageComboSequence(input, maxCarriableWeight)
+
+    expect(result).toEqual([
+      [
+        {
+          packageId: 'pkg1',
+          weightInKg: 140,
+          distanceInKm: 100,
+          offerCode: 'off001',
+          baseDeliveryCost: 100,
+          sequence: 0,
+        },
+        {
+          packageId: 'pkg2',
+          weightInKg: 60,
+          distanceInKm: 200,
+          offerCode: 'off008',
+          baseDeliveryCost: 100,
+          sequence: 1,
+        },
+      ],
+      [
+        {
+          packageId: 'pkg3',
+          weightInKg: 130,
+          distanceInKm: 100,
+          offerCode: 'off003',
+          baseDeliveryCost: 100,
+          sequence: 2,
+        },
+        {
+          packageId: 'pkg4',
+          weightInKg: 70,
+          distanceInKm: 100,
+          offerCode: 'off002',
+          baseDeliveryCost: 100,
+          sequence: 3,
+        },
+      ],
+      [
+        {
+          packageId: 'pkg5',
+          weightInKg: 100,
+          distanceInKm: 100,
+          offerCode: 'off001',
+          baseDeliveryCost: 100,
+          sequence: 4,
+        },
+      ],
+    ])
+  })
+})

--- a/src/use-case/delivery-time/utils/get-package-combo-sequence.ts
+++ b/src/use-case/delivery-time/utils/get-package-combo-sequence.ts
@@ -1,0 +1,23 @@
+import { PackageDtoForTime } from '../delivery-time.dto'
+import { getPackageComboPerTrip } from './get-package-combo-per-trip'
+
+export function getPackageComboSequence(
+  packageList: PackageDtoForTime[],
+  maxCarriableWeight: number,
+): PackageDtoForTime[][] {
+  let remainingPackages = [...packageList]
+  let deliveryComboSequence = [] as PackageDtoForTime[][]
+
+  while (remainingPackages.length > 0) {
+    const toBeTrained = [...remainingPackages]
+
+    const combo = getPackageComboPerTrip(toBeTrained, maxCarriableWeight)
+    deliveryComboSequence.push(combo)
+
+    remainingPackages = remainingPackages.filter(
+      (eachPackage) => !combo.includes(eachPackage),
+    )
+  }
+
+  return deliveryComboSequence
+}

--- a/src/use-case/delivery-time/utils/mocks/mock-delivery-time-standard-requirement.mock.ts
+++ b/src/use-case/delivery-time/utils/mocks/mock-delivery-time-standard-requirement.mock.ts
@@ -1,0 +1,52 @@
+import { PackageDtoForTime } from '../../delivery-time.dto'
+
+/**
+ * @description
+ * Input stimulate standard requirement
+ * - PKG2,  PKG4
+ * - PKG3
+ * - PKG5
+ * - PKG1
+ */
+export const mockedDeliveryTimeStandardRequirement: PackageDtoForTime[] = [
+  {
+    packageId: 'pkg1',
+    weightInKg: 50,
+    distanceInKm: 30,
+    offerCode: 'off001',
+    baseDeliveryCost: 100,
+    sequence: 0,
+  },
+  {
+    packageId: 'pkg2',
+    weightInKg: 75,
+    distanceInKm: 125,
+    offerCode: 'off008',
+    baseDeliveryCost: 100,
+    sequence: 1,
+  },
+  {
+    packageId: 'pkg3',
+    weightInKg: 175,
+    distanceInKm: 100,
+    offerCode: 'off003',
+    baseDeliveryCost: 100,
+    sequence: 2,
+  },
+  {
+    packageId: 'pkg4',
+    weightInKg: 110,
+    distanceInKm: 60,
+    offerCode: 'off002',
+    baseDeliveryCost: 100,
+    sequence: 3,
+  },
+  {
+    packageId: 'pkg5',
+    weightInKg: 155,
+    distanceInKm: 95,
+    offerCode: 'off001',
+    baseDeliveryCost: 100,
+    sequence: 4,
+  },
+]

--- a/src/use-case/delivery-time/utils/mocks/mock-five-packages-should-send-first.mock.ts
+++ b/src/use-case/delivery-time/utils/mocks/mock-five-packages-should-send-first.mock.ts
@@ -1,0 +1,50 @@
+import { PackageDtoForTime } from '../../delivery-time.dto'
+
+/**
+ * @description
+ * Input stimulate 5 packages should send first
+ * - PKG1, PKG2, PKG3,PKG4, PKG5
+ * 1 trips
+ */
+export const mockFivePackagesShouldSendFirst: PackageDtoForTime[] = [
+  {
+    packageId: 'pkg1',
+    weightInKg: 30,
+    distanceInKm: 100,
+    offerCode: 'off002',
+    baseDeliveryCost: 100,
+    sequence: 0,
+  },
+  {
+    packageId: 'pkg2',
+    weightInKg: 50,
+    distanceInKm: 100,
+    offerCode: 'off001',
+    baseDeliveryCost: 100,
+    sequence: 1,
+  },
+  {
+    packageId: 'pkg3',
+    weightInKg: 40,
+    distanceInKm: 100,
+    offerCode: 'off003',
+    baseDeliveryCost: 100,
+    sequence: 2,
+  },
+  {
+    packageId: 'pkg4',
+    weightInKg: 70,
+    distanceInKm: 100,
+    offerCode: 'off001',
+    baseDeliveryCost: 100,
+    sequence: 3,
+  },
+  {
+    packageId: 'pkg5',
+    weightInKg: 5,
+    distanceInKm: 100,
+    offerCode: 'off001',
+    baseDeliveryCost: 100,
+    sequence: 4,
+  },
+]

--- a/src/use-case/delivery-time/utils/mocks/mock-four-packages-should-send-first.mock.ts
+++ b/src/use-case/delivery-time/utils/mocks/mock-four-packages-should-send-first.mock.ts
@@ -1,0 +1,51 @@
+import { PackageDtoForTime } from '../../delivery-time.dto'
+
+/**
+ * @description
+ * Input stimulate 4 packages should send first
+ * - PKG1, PKG2, PKG3, PKG4
+ * - PKG5
+ * 2 trips
+ */
+export const mockedFourPackageShouldDeliveryFirst: PackageDtoForTime[] = [
+  {
+    packageId: 'pkg1',
+    weightInKg: 30,
+    distanceInKm: 100,
+    offerCode: 'off002',
+    baseDeliveryCost: 100,
+    sequence: 0,
+  },
+  {
+    packageId: 'pkg2',
+    weightInKg: 50,
+    distanceInKm: 100,
+    offerCode: 'off001',
+    baseDeliveryCost: 100,
+    sequence: 1,
+  },
+  {
+    packageId: 'pkg3',
+    weightInKg: 40,
+    distanceInKm: 100,
+    offerCode: 'off003',
+    baseDeliveryCost: 100,
+    sequence: 2,
+  },
+  {
+    packageId: 'pkg4',
+    weightInKg: 70,
+    distanceInKm: 100,
+    offerCode: 'off001',
+    baseDeliveryCost: 100,
+    sequence: 3,
+  },
+  {
+    packageId: 'pkg5',
+    weightInKg: 100,
+    distanceInKm: 100,
+    offerCode: 'off001',
+    baseDeliveryCost: 100,
+    sequence: 4,
+  },
+]

--- a/src/use-case/delivery-time/utils/mocks/mock-three-packages-should-send-first..mock.ts
+++ b/src/use-case/delivery-time/utils/mocks/mock-three-packages-should-send-first..mock.ts
@@ -1,0 +1,51 @@
+import { PackageDtoForTime } from '../../delivery-time.dto'
+
+/**
+ * @description
+ * 3 packages should send first
+ * - PKG1, PKG2, PKG5
+ * - PKG3,
+ * - PKG4
+ */
+export const mockedThreePackagesShouldSendFirst: PackageDtoForTime[] = [
+  {
+    packageId: 'pkg1',
+    weightInKg: 50,
+    distanceInKm: 100,
+    offerCode: 'off001',
+    baseDeliveryCost: 100,
+    sequence: 0,
+  },
+  {
+    packageId: 'pkg2',
+    weightInKg: 50,
+    distanceInKm: 100,
+    offerCode: 'off008',
+    baseDeliveryCost: 100,
+    sequence: 1,
+  },
+  {
+    packageId: 'pkg3',
+    weightInKg: 150,
+    distanceInKm: 100,
+    offerCode: 'off003',
+    baseDeliveryCost: 100,
+    sequence: 2,
+  },
+  {
+    packageId: 'pkg4',
+    weightInKg: 99,
+    distanceInKm: 100,
+    offerCode: 'off002',
+    baseDeliveryCost: 100,
+    sequence: 3,
+  },
+  {
+    packageId: 'pkg5',
+    weightInKg: 100,
+    distanceInKm: 100,
+    offerCode: 'off001',
+    baseDeliveryCost: 100,
+    sequence: 4,
+  },
+]

--- a/src/use-case/delivery-time/utils/mocks/mock-two-combo-same-length-and-weight-different-distance.mock.ts
+++ b/src/use-case/delivery-time/utils/mocks/mock-two-combo-same-length-and-weight-different-distance.mock.ts
@@ -1,0 +1,53 @@
+import { PackageDtoForTime } from '../../delivery-time.dto'
+
+/**
+ * @description
+ * 2 packages should send first
+ * 3 trips
+ * - PKG1, PKG2,
+ * - PKG3, PKG4
+ * - PKG5
+ */
+export const mockedTwoComboSameLengthAndWeightDifferenceDistance: PackageDtoForTime[] =
+  [
+    {
+      packageId: 'pkg1',
+      weightInKg: 140,
+      distanceInKm: 100,
+      offerCode: 'off001',
+      baseDeliveryCost: 100,
+      sequence: 0,
+    },
+    {
+      packageId: 'pkg2',
+      weightInKg: 60,
+      distanceInKm: 200,
+      offerCode: 'off008',
+      baseDeliveryCost: 100,
+      sequence: 1,
+    },
+    {
+      packageId: 'pkg3',
+      weightInKg: 130,
+      distanceInKm: 100,
+      offerCode: 'off003',
+      baseDeliveryCost: 100,
+      sequence: 2,
+    },
+    {
+      packageId: 'pkg4',
+      weightInKg: 70,
+      distanceInKm: 100,
+      offerCode: 'off002',
+      baseDeliveryCost: 100,
+      sequence: 3,
+    },
+    {
+      packageId: 'pkg5',
+      weightInKg: 100,
+      distanceInKm: 100,
+      offerCode: 'off001',
+      baseDeliveryCost: 100,
+      sequence: 4,
+    },
+  ]

--- a/src/use-case/delivery-time/utils/mocks/mock-two-combo-same-length-different-weight.mock.ts
+++ b/src/use-case/delivery-time/utils/mocks/mock-two-combo-same-length-different-weight.mock.ts
@@ -1,0 +1,52 @@
+import { PackageDtoForTime } from '../../delivery-time.dto'
+
+/**
+ * @description
+ * 2 packages should send first
+ * 3 trips
+ * - PKG1, PKG2, 200kg
+ * - PKG3, PKG4, 190kg
+ * - PKG5
+ */
+export const mockedTwoComboSameLengthDifferentWeight: PackageDtoForTime[] = [
+  {
+    packageId: 'pkg1',
+    weightInKg: 140,
+    distanceInKm: 100,
+    offerCode: 'off001',
+    baseDeliveryCost: 100,
+    sequence: 0,
+  },
+  {
+    packageId: 'pkg2',
+    weightInKg: 60,
+    distanceInKm: 200,
+    offerCode: 'off008',
+    baseDeliveryCost: 100,
+    sequence: 1,
+  },
+  {
+    packageId: 'pkg3',
+    weightInKg: 130,
+    distanceInKm: 100,
+    offerCode: 'off003',
+    baseDeliveryCost: 100,
+    sequence: 2,
+  },
+  {
+    packageId: 'pkg4',
+    weightInKg: 50,
+    distanceInKm: 100,
+    offerCode: 'off002',
+    baseDeliveryCost: 100,
+    sequence: 3,
+  },
+  {
+    packageId: 'pkg5',
+    weightInKg: 100,
+    distanceInKm: 100,
+    offerCode: 'off001',
+    baseDeliveryCost: 100,
+    sequence: 4,
+  },
+]

--- a/src/use-case/delivery-time/utils/mocks/mock-ultimate-situation.mock.ts
+++ b/src/use-case/delivery-time/utils/mocks/mock-ultimate-situation.mock.ts
@@ -1,0 +1,73 @@
+import { PackageDtoForTime } from '../../delivery-time.dto'
+
+/**
+ * @description
+ * Input stimulate 7 packages with below situation
+ * - PKG1, PKG2, PKG3, total weight 200kg, highest weight
+ * - All 100km/70 = 1.42 hours/km
+ * - pkg6, pkg7 total 195kg, highest weight, distance 190km
+ * - pkg5, pkg8,total 175kg, highest weight, distance 160km
+
+ * Total 3 trips
+ * This will cover all the situation together
+ * - Maximize no of packages
+ * - If same no of package, Maximize weight
+ */
+export const mockUltimateSituation: PackageDtoForTime[] = [
+  {
+    packageId: 'pkg1',
+    weightInKg: 30,
+    distanceInKm: 100,
+    offerCode: 'off002',
+    baseDeliveryCost: 100,
+    sequence: 0,
+  },
+  {
+    packageId: 'pkg2',
+    weightInKg: 50,
+    distanceInKm: 100,
+    offerCode: 'off001',
+    baseDeliveryCost: 100,
+    sequence: 1,
+  },
+  {
+    packageId: 'pkg3',
+    weightInKg: 120,
+    distanceInKm: 100,
+    offerCode: 'off003',
+    baseDeliveryCost: 100,
+    sequence: 2,
+  },
+  {
+    packageId: 'pkg5',
+    weightInKg: 100,
+    distanceInKm: 90,
+    offerCode: 'off001',
+    baseDeliveryCost: 100,
+    sequence: 3,
+  },
+  {
+    packageId: 'pkg6',
+    weightInKg: 85,
+    distanceInKm: 90,
+    offerCode: 'off002',
+    baseDeliveryCost: 100,
+    sequence: 4,
+  },
+  {
+    packageId: 'pkg7',
+    weightInKg: 110,
+    distanceInKm: 100,
+    offerCode: 'off001',
+    baseDeliveryCost: 100,
+    sequence: 5,
+  },
+  {
+    packageId: 'pkg8',
+    weightInKg: 75,
+    distanceInKm: 70,
+    offerCode: 'off003',
+    baseDeliveryCost: 100,
+    sequence: 6,
+  },
+]


### PR DESCRIPTION
Summary 

- Change algorithm of `getPackageComboPerTrip`, using Improper subset method, to cover the edge cases ([Some high level thinking here](https://github.com/kenchoong/courrier-service/issues/10#issuecomment-1289334176))
- Helper method `decideSendFirstCombo`  and test cases 
- Helper method `getPackageComboSequence` and test cases 
- Use `getPackageComboSequence` in `DeliveryTimeService` file 
- Remove comment in `DeliveryTimeService` 
- Add more test case in `DeliveryTimeService` to cover edge case 
- Create separate mock file for better reusability in multiple test case and easier to work in IDE

Mainly solve this reported issue: https://github.com/kenchoong/courrier-service/issues/10 